### PR TITLE
Remove assertions when mapping value to countsArray index

### DIFF
--- a/kamon-apm-reporter/src/main/scala/kamon/apm/package.scala
+++ b/kamon-apm-reporter/src/main/scala/kamon/apm/package.scala
@@ -83,8 +83,6 @@ package object apm {
     val SubBucketMask               = (SubBucketCount.toLong - 1) << UnitMagnitude
 
     def countsArrayIndex(bucketIndex: Int, subBucketIndex: Int): Int = {
-      assert(subBucketIndex < SubBucketCount)
-      assert(bucketIndex == 0 || (subBucketIndex >= SubBucketHalfCount))
       val bucketBaseIndex = (bucketIndex + 1) << SubBucketHalfCountMagnitude
       val offsetInBucket = subBucketIndex - SubBucketHalfCount
       bucketBaseIndex + offsetInBucket


### PR DESCRIPTION
Since index calculated here is used to construct a compacted histogram snapshot
and not index the actual counts array, we are removing the assertions that would
prevent index overflowing backing-histogram's dynamic range.

This is required in order to pack gauge values as histograms since gauges are not
capped by backing-histogram's maxTrackableValue